### PR TITLE
Improved strategy for reset to bootloader, fixing nodemcu reset issue

### DIFF
--- a/esputil.c
+++ b/esputil.c
@@ -721,6 +721,8 @@ static void readflash(struct ctx *ctx, const char **args) {
       }
     }
   }
+
+  hard_reset(ctx->fd);
 }
 
 static inline unsigned long hex_to_ul(const char *s, int len) {


### PR DESCRIPTION
Improved strategy for resetting to the bootloader. Without this, the `boot` button of NodeMCU-ESP32 DevKITV1 has to be pressed manually in order to enter the bootloader. But with this fix, it automatically enters the bootloader.

The reset strategy and sequence have been taken from the official `esptool` code.

Also added `hard_reset()` calls at the end of the read and write functions. 